### PR TITLE
(feat) Close function is coroutine

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ip_addresses = await resolve('www.google.com', TYPES.A)
 # Will only make another request to the nameserver(s) if the ip_addresses have expired
 ip_addresses = await resolve('www.google.com', TYPES.A)
 
-clear_cache()
+await clear_cache()
 # Will make another request to the nameserver(s)
 ip_addresses = await resolve('www.google.com', TYPES.A)
 ```
@@ -237,7 +237,7 @@ class AioHttpDnsResolver(aiohttp.abc.AbstractResolver):
         } for ip_address in ip_addresses]
 
     async def close(self):
-        self.clear_cache()
+        await self.clear_cache()
 
 
 async def main():
@@ -292,7 +292,7 @@ class AioHttpDnsResolver(tornado.netutil.Resolver):
         ]
 
     async def close(self):
-        self.clear_cache()
+        await self.clear_cache()
 
 async def main():
     tornado.netutil.Resolver.configure(AioHttpDnsResolver)

--- a/aiodnsresolver.py
+++ b/aiodnsresolver.py
@@ -387,7 +387,7 @@ def Resolver(
         del cache[key]
         invalidate_callbacks.pop(key).cancel()
 
-    def invalidate_all():
+    async def invalidate_all():
         for callback in invalidate_callbacks.values():
             callback.cancel()
         invalidate_callbacks.clear()

--- a/test.py
+++ b/test.py
@@ -113,7 +113,7 @@ class TestResolverIntegration(unittest.TestCase):
             self.assertEqual(queried_names[1].lower(), b'my.domain.quite-long.abcdefghijklm')
             self.assertEqual(str(res_4[0]), '123.100.123.2')
 
-            invalidate()
+            await invalidate()
             res_5 = await resolve('my.domain.quite-long.abcdefghijklm', TYPES.A)
             self.assertEqual(len(queried_names), 3)
             self.assertEqual(queried_names[2].lower(), b'my.domain.quite-long.abcdefghijklm')
@@ -1412,7 +1412,7 @@ class TestResolverIntegration(unittest.TestCase):
                 } for ip_address in ip_addresses]
 
             async def close(self):
-                self.clear_cache()
+                await self.clear_cache()
 
         loop = asyncio.get_event_loop()
         self.addCleanup(patch_open())


### PR DESCRIPTION
This is so the resolver can be wrapped with something that has the same
interface, but more complex async behaviour on closing