### PR TITLE
Fix parsing of TXT responses

### DIFF
--- a/aiodnsresolver.py
+++ b/aiodnsresolver.py
@@ -206,6 +206,30 @@ def parse(data):
             else:
                 break
 
+    def load_char_strings(dc):
+        nonlocal c
+
+        local_cursor = c
+        last_str = False
+
+        while not last_str:
+            str_len = data[local_cursor]
+
+            local_cursor += 1
+
+            # make sure we don't go off the end
+            if (local_cursor + str_len) >= dc:
+                str_end = local_cursor + dc
+                last_str = True
+            else:
+                str_end = local_cursor + str_len
+
+            cur_str = data[local_cursor:str_end]
+
+            yield cur_str
+
+            local_cursor = (str_end + 1)
+
     def split_bits(num, *lengths):
         for length in lengths:
             high = num >> length
@@ -230,6 +254,8 @@ def parse(data):
         ttl, dc = unpack(STRUCT_TTL_RDATALEN)
         if qtype == TYPES.CNAME:
             rdata = b'.'.join(load_labels())
+        elif qtype == TYPES.TXT:
+            rdata = b''.join(load_char_strings(dc))
         else:
             rdata = data[c: c + dc]
             c += dc

--- a/aiodnsresolver.py
+++ b/aiodnsresolver.py
@@ -255,7 +255,7 @@ def parse(data):
         if qtype == TYPES.CNAME:
             rdata = b'.'.join(load_labels())
         elif qtype == TYPES.TXT:
-            rdata = b''.join(load_char_strings(dc))
+            rdata = b' '.join([b'"%b"' % cs for cs in load_char_strings(dc)])
             c += dc
         else:
             rdata = data[c: c + dc]

--- a/aiodnsresolver.py
+++ b/aiodnsresolver.py
@@ -599,6 +599,7 @@ def Resolver(
                     for answer in res.an
                     if answer.name.lower() == name_lower and answer.qtype == qtype
                 )
+
                 if non_name_error:
                     last_exception = DnsResponseCode(res.rcode)
                     set_timeout_cause(last_exception)
@@ -619,7 +620,8 @@ def Resolver(
         return \
             IPv4AddressExpiresAt(record.rdata, expires_at) if record.qtype == TYPES.A else \
             IPv6AddressExpiresAt(record.rdata, expires_at) if record.qtype == TYPES.AAAA else \
-            BytesExpiresAt(record.rdata.lower(), expires_at)
+            BytesExpiresAt(record.rdata.lower(), expires_at) if record.qtype == TYPES.CNAME else\
+            BytesExpiresAt(record.rdata, expires_at)
 
     def rdata_expires_at_min(rdatas, expires_at):
         return tuple(

--- a/aiodnsresolver.py
+++ b/aiodnsresolver.py
@@ -220,15 +220,18 @@ def parse(data):
 
             # make sure we don't go off the end
             if (str_start_i + str_len) >= end_i:
-                str_end_i = end_i
+                str_end_count = end_i
                 last_str = True
 
             else:
-                str_end_i = str_start_i + str_len
+                str_end_count = str_start_i + str_len
 
-            cur_str = data[str_start_i:str_end_i]
+            cur_str = data[str_start_i:str_end_count]
             yield cur_str
-            str_len_i = str_end_i + 1
+            # if we slice n characters, the next string starts 
+            # at *index* n
+            str_len_i = str_end_count
+
 
     def split_bits(num, *lengths):
         for length in lengths:

--- a/aiodnsresolver.py
+++ b/aiodnsresolver.py
@@ -207,28 +207,28 @@ def parse(data):
                 break
 
     def load_char_strings(dc):
+
         nonlocal c
 
-        local_cursor = c
+        str_len_i = c
+        end_i = c + dc
         last_str = False
 
         while not last_str:
-            str_len = data[local_cursor]
-
-            local_cursor += 1
+            str_len = data[str_len_i]
+            str_start_i = str_len_i + 1
 
             # make sure we don't go off the end
-            if (local_cursor + str_len) >= dc:
-                str_end = local_cursor + dc
+            if (str_start_i + str_len) >= end_i:
+                str_end_i = end_i
                 last_str = True
+
             else:
-                str_end = local_cursor + str_len
+                str_end_i = str_start_i + str_len
 
-            cur_str = data[local_cursor:str_end]
-
+            cur_str = data[str_start_i:str_end_i]
             yield cur_str
-
-            local_cursor = (str_end + 1)
+            str_len_i = str_end_i + 1
 
     def split_bits(num, *lengths):
         for length in lengths:
@@ -256,6 +256,7 @@ def parse(data):
             rdata = b'.'.join(load_labels())
         elif qtype == TYPES.TXT:
             rdata = b''.join(load_char_strings(dc))
+            c += dc
         else:
             rdata = data[c: c + dc]
             c += dc


### PR DESCRIPTION
For TXT responses, RDATA consists of character strings, of which the first byte is the length of the string.  Currently this is returned along with the actual character data.  This patch will return the concatenation of all character strings, minus length metadata, found in RDATA