### PR TITLE
fix: set timeout on socket connect in order to prevent infinite block

### DIFF
--- a/aiodnsresolver.py
+++ b/aiodnsresolver.py
@@ -512,6 +512,7 @@ def Resolver(
                     set_sock_options(sock)
                     sock.settimeout(timeout)
                     sock.connect(addr_port)
+                    sock.settimeout(None)
                 except OSError as exception:
                     last_exception = exception
                     set_timeout_cause(exception)

--- a/aiodnsresolver.py
+++ b/aiodnsresolver.py
@@ -478,7 +478,7 @@ def Resolver(
             last_exception = exception
 
         try:
-            return await request(logger, addrs, fqdn, qtype, set_timeout_cause)
+            return await request(logger, addrs, fqdn, qtype, timeout, set_timeout_cause)
         except CancelledError:
             if cancelling_due_to_timeout:
                 raise DnsTimeout() from last_exception
@@ -488,7 +488,7 @@ def Resolver(
         finally:
             handle.cancel()
 
-    async def request(logger, addrs, fqdn, qtype, set_timeout_cause):
+    async def request(logger, addrs, fqdn, qtype, timeout, set_timeout_cause):
         async def req():
             qid = randbelow(65536)
             fqdn_transformed = await transform_fqdn(fqdn)
@@ -510,6 +510,7 @@ def Resolver(
                 try:
                     sock.setblocking(False)
                     set_sock_options(sock)
+                    sock.settimeout(timeout)
                     sock.connect(addr_port)
                 except OSError as exception:
                     last_exception = exception


### PR DESCRIPTION
# Background
We had a situation where this `sock.connect` blocked forever inside a container, in order to avoid such a situation in the future we ensured the connection was secured by the same timeout we granted the request.