### PR TITLE
fix: don't lowercase TXT records

### DIFF
--- a/aiodnsresolver.py
+++ b/aiodnsresolver.py
@@ -605,7 +605,8 @@ def Resolver(
         return \
             IPv4AddressExpiresAt(record.rdata, expires_at) if record.qtype == TYPES.A else \
             IPv6AddressExpiresAt(record.rdata, expires_at) if record.qtype == TYPES.AAAA else \
-            BytesExpiresAt(record.rdata.lower(), expires_at)
+            BytesExpiresAt(record.rdata.lower(), expires_at) if record.qtype == TYPES.CNAME else \
+            BytesExpiresAt(record.rdata, expires_at)
 
     def rdata_expires_at_min(rdatas, expires_at):
         return tuple(

--- a/test.py
+++ b/test.py
@@ -1688,6 +1688,8 @@ class TestResolverEndToEnd(unittest.TestCase):
     async def test_txt_query(self):
         resolve, _ = Resolver()
         res = await resolve('charemza.name', TYPES.TXT)
+        all_lowercase = all(r == r.lower() for r in res)
+        self.assertFalse(all_lowercase)
         self.assertIn(b'google', res[0])
 
     @async_test


### PR DESCRIPTION
This is borderline out of scope of aiodnsresolver, but it's a small fix. Addresses some of https://github.com/michalc/aiodnsresolver/pull/31