### PR TITLE
Fix memoized mutex

### DIFF
--- a/aiodnsresolver.py
+++ b/aiodnsresolver.py
@@ -657,6 +657,7 @@ def MemoizedMutex(func, *args):
             raise
 
         if has_result:
+            acquired = False
             return result
 
         try:


### PR DESCRIPTION
`MemoizedMutex` is not stable and can hang when used after it has returned a result, as indicated by the tests. This instability arises because `WeakValueDictionary` does not guarantee immediate destruction of the value once it is no longer in use.